### PR TITLE
✨ Notice 공지 현황/팝업/숨기기

### DIFF
--- a/back/db/notice.js
+++ b/back/db/notice.js
@@ -2,16 +2,14 @@ const mongoose = require('mongoose');
 const { noticeDB } = require('./mongodb'); // ✅ noticeDB 가져오기
 
 const noticeSchema = new mongoose.Schema({
-  notice_idx: { type: String, required: true, unique: true }, // 홍보물 ID
-  account_idx: { type: String, required: true }, // 작성자 ID
-  title: { type: String, required: true }, // 제목
-  contents: { type: String }, // 내용 (첨부파일 가능)
-  file_url: { type: String }, // 업로드된 파일 URL
-  createdAt: { type: Date, default: Date.now }, // 생성 시간
-  updatedAt: { type: Date, default: Date.now }, // 수정 시간
-  endtime: { type: Date }, // 종료 시간 (있으면 비활성화)
-  views: { type: Number, default: 0 } // 조회수
+  admin_info_id: { type: String, required: true },   // 작성자 ID (ex: 이메일 또는 ObjectId)
+  type: { type: Boolean, required: true },           // 팝업 여부 (true = 팝업 공지)
+  start_date: { type: Date, required: true },        // 공지 시작 날짜
+  end_date: { type: Date, required: true },          // 공지 종료 날짜
+  title: { type: String, required: true },           // 제목
+  contents: { type: String },                        // 공지 내용
+  created_at: { type: Date, default: Date.now }      // 생성일시
 }, { versionKey: false });
 
-const Notice = noticeDB.model('Notice', noticeSchema, 'board'); // ✅ `board` 컬렉션에 저장
+const Notice = noticeDB.model('Notice', noticeSchema, 'board'); // ✅ board 컬렉션에 저장
 module.exports = Notice;

--- a/back/db/notice.js
+++ b/back/db/notice.js
@@ -11,5 +11,5 @@ const noticeSchema = new mongoose.Schema({
   created_at: { type: Date, default: Date.now }      // 생성일시
 }, { versionKey: false });
 
-const Notice = noticeDB.model('Notice', noticeSchema, 'board'); // ✅ board 컬렉션에 저장
+const Notice = noticeDB.model('Notice', noticeSchema, 'notices');
 module.exports = Notice;

--- a/back/db/noticePopup.js
+++ b/back/db/noticePopup.js
@@ -1,0 +1,9 @@
+const mongoose = require("mongoose");
+const { noticeDB } = require("./mongodb");
+
+const noticePopupSchema = new mongoose.Schema({
+  studentId: { type: String, required: true },
+  noticeId: { type: mongoose.Schema.Types.ObjectId, required: true }
+}, { versionKey: false });
+
+module.exports = noticeDB.model("NoticePopup", noticePopupSchema, "notice-popup");

--- a/back/db/noticePopup.js
+++ b/back/db/noticePopup.js
@@ -6,4 +6,4 @@ const noticePopupSchema = new mongoose.Schema({
   noticeId: { type: mongoose.Schema.Types.ObjectId, required: true }
 }, { versionKey: false });
 
-module.exports = noticeDB.model("NoticePopup", noticePopupSchema, "notice-popup");
+module.exports = noticeDB.model("NoticePopup", noticePopupSchema, "notice_popup");

--- a/back/routes/hiddenPopup.js
+++ b/back/routes/hiddenPopup.js
@@ -1,0 +1,26 @@
+const express = require("express");
+const router = express.Router();
+const NoticePopup = require("../db/noticePopup");
+
+// POST /api/hidden-popup
+router.put("/hidden-popup", async (req, res) => {
+  try {
+    const { studentId, noticeId } = req.body;
+    if (!studentId || !noticeId) {
+      return res.status(400).json({ message: "필수 데이터 누락" });
+    }
+
+    const existing = await NoticePopup.findOne({ studentId, noticeId });
+    if (existing) {
+      return res.status(200).json({ success: true }); // 이미 숨긴 경우도 OK 처리
+    }
+
+    await NoticePopup.create({ studentId, noticeId });
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    console.error("hidden-popup 오류:", err);
+    res.status(500).json({ message: "서버 오류" });
+  }
+});
+
+module.exports = router;

--- a/back/routes/noticeDetail.js
+++ b/back/routes/noticeDetail.js
@@ -1,0 +1,34 @@
+const express = require("express");
+const router = express.Router();
+const Notice = require("../db/notice");
+const { Types } = require("mongoose");
+
+// POST /api/notice-detail
+router.post("/notice-detail", async (req, res) => {
+  try {
+    const { id } = req.body;
+
+    if (!id) {
+      return res.status(400).json({ message: "id가 필요합니다." });
+    }
+
+    const notice = await Notice.findById(id).lean();
+
+    if (!notice) {
+      return res.status(404).json({ message: "공지사항을 찾을 수 없습니다." });
+    }
+
+    return res.status(200).json({
+      id: notice._id,
+      created_at: new Date(notice.created_at).toISOString().slice(0, 10),
+      type: notice.type,
+      title: notice.title,
+      contents: notice.contents
+    });
+  } catch (err) {
+    console.error("notice-detail 오류:", err);
+    return res.status(500).json({ message: "서버 오류" });
+  }
+});
+
+module.exports = router;

--- a/back/routes/noticeList.js
+++ b/back/routes/noticeList.js
@@ -1,0 +1,24 @@
+const express = require("express");
+const router = express.Router();
+const Notice = require("../db/notice");
+
+// GET /api/notice-list
+router.get("/notice-list", async (req, res) => {
+  try {
+    const notices = await Notice.find({}).sort({ created_at: -1 }).lean(); // 최신순 정렬
+
+    const simplified = notices.map(n => ({
+      id: n._id,
+      created_at: new Date(n.created_at).toISOString().slice(0, 10), // ✅ 날짜만 자르기
+      type: n.type,
+      title: n.title
+    }));
+
+    return res.status(200).json(simplified);
+  } catch (err) {
+    console.error("notice-list 오류:", err);
+    return res.status(500).json({ message: "서버 오류" });
+  }
+});
+
+module.exports = router;

--- a/back/routes/showPopup
+++ b/back/routes/showPopup
@@ -1,0 +1,39 @@
+const express = require("express");
+const router = express.Router();
+const Notice = require("../db/notice");
+const NoticePopup = require("../db/noticePopup");
+
+router.post("/show-notice-popup", async (req, res) => {
+  try {
+    const { studentId } = req.body;
+    if (!studentId) {
+      return res.status(400).json({ message: "studentId가 필요합니다." });
+    }
+
+    // 모든 팝업 공지
+    const popupNotices = await Notice.find({ type: true }).lean();
+
+    // 숨김 기록 조회
+    const hiddenRecords = await NoticePopup.find({ studentId }).lean();
+    const hiddenIds = hiddenRecords.map(r => r.noticeId.toString());
+
+    // 숨기지 않은 공지만 필터링
+    const visibleNotices = popupNotices
+      .filter(n => !hiddenIds.includes(n._id.toString()))
+      .map(n => ({
+        id: n._id,
+        start_date: n.start_date.toISOString().slice(0, 10),
+        end_date: n.end_date.toISOString().slice(0, 10),
+        title: n.title,
+        contents: n.contents,
+        isHidden: false
+      }));
+
+    return res.status(200).json(visibleNotices);
+  } catch (err) {
+    console.error("show-notice-popup 오류:", err);
+    res.status(500).json({ message: "서버 오류" });
+  }
+});
+
+module.exports = router;

--- a/back/routes/showPopup
+++ b/back/routes/showPopup
@@ -13,23 +13,23 @@ router.post("/show-notice-popup", async (req, res) => {
     // 모든 팝업 공지
     const popupNotices = await Notice.find({ type: true }).lean();
 
-    // 숨김 기록 조회
+    // 숨긴 공지 목록 조회
     const hiddenRecords = await NoticePopup.find({ studentId }).lean();
     const hiddenIds = hiddenRecords.map(r => r.noticeId.toString());
 
-    // 숨기지 않은 공지만 필터링
-    const visibleNotices = popupNotices
-      .filter(n => !hiddenIds.includes(n._id.toString()))
-      .map(n => ({
+    const noticesWithHiddenFlag = popupNotices.map(n => {
+    const isHidden = hiddenIds.includes(n._id.toString());  // ✅ 문자열로 비교
+    return {
         id: n._id,
         start_date: n.start_date.toISOString().slice(0, 10),
         end_date: n.end_date.toISOString().slice(0, 10),
         title: n.title,
         contents: n.contents,
-        isHidden: false
-      }));
+        isHidden
+    };
+    });
 
-    return res.status(200).json(visibleNotices);
+    return res.status(200).json(noticesWithHiddenFlag);
   } catch (err) {
     console.error("show-notice-popup 오류:", err);
     res.status(500).json({ message: "서버 오류" });

--- a/back/server.js
+++ b/back/server.js
@@ -32,7 +32,7 @@ app.use("/api", require("./routes/reservationList"));
 app.use("/api", require("./routes/updatereserve"));
 app.use("/api", require("./routes/deletereserve"));
 app.use("/api", require("./routes/getreserve"));
-
+app.use("/api", require("./routes/noticeList"));
 
 // 서버 실행
 const PORT = process.env.PORT || 4000;

--- a/back/server.js
+++ b/back/server.js
@@ -35,6 +35,7 @@ app.use("/api", require("./routes/getreserve"));
 app.use("/api", require("./routes/noticeList"));
 app.use("/api", require("./routes/noticeDetail"));
 app.use("/api", require("./routes/showPopup"));
+app.use("/api", require("./routes/hiddenPopup"));
 
 // 서버 실행
 const PORT = process.env.PORT || 4000;

--- a/back/server.js
+++ b/back/server.js
@@ -33,6 +33,7 @@ app.use("/api", require("./routes/updatereserve"));
 app.use("/api", require("./routes/deletereserve"));
 app.use("/api", require("./routes/getreserve"));
 app.use("/api", require("./routes/noticeList"));
+app.use("/api", require("./routes/noticeDetail"));
 
 // 서버 실행
 const PORT = process.env.PORT || 4000;

--- a/back/server.js
+++ b/back/server.js
@@ -34,6 +34,7 @@ app.use("/api", require("./routes/deletereserve"));
 app.use("/api", require("./routes/getreserve"));
 app.use("/api", require("./routes/noticeList"));
 app.use("/api", require("./routes/noticeDetail"));
+app.use("/api", require("./routes/showPopup"));
 
 // 서버 실행
 const PORT = process.env.PORT || 4000;


### PR DESCRIPTION
### 👀 관련 이슈
#68 
### ✨ 작업한 내용

- notice-list 
공지 정보 모두 불러오기    
- notice-detail
{"id": "공지글 아이디"} 프론트에서 보내면,  { id, create_at, type, title, contents } 보내주기

- show-notice-popup
{"studentId": "2022204062"} 프론트에서 보내면, [{ id, start_date, end_date, title, contents, isHidden }] 보내주기

- hidden-popup
{
  "studentId": "2021204083",
  "noticeId": "67ebf37571355a3d3b439bcc"
}
프론트에서 보내면, isHidden 값 바꾸고, notice_popup DB에  {_id, studentId , noticeId} 추가한 뒤
백엔드에서 { "success": true } 보내주기

### 🌀 PR Point

hidden-popup에서 초기에는 studentId만 보내는 걸로 되어 있었는데, 그러면 어느 게시물을 hidden버튼을 눌렀는지 몰라서 나중에 숨기는게 어려운 것 같아, noticeid도 같이 추가했습니다.

### 🍰 참고사항

<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
[notice-list]
관리자용에서 등록해놓은 모든 공지 불러오기(Type true가 팝업)
![image](https://github.com/user-attachments/assets/137a5004-ffcb-4ae0-ab3a-956ed5581d83)

[notice-detail]
공지 id있을때 세부사항 보내줌
![image](https://github.com/user-attachments/assets/572646f0-9862-47de-a66a-979963f265ca)

[show-notice-popup]
Notice에서 Type이 true인 애들만 불러옴(팝업인 경우임)
기본적으로 사용자가 버튼을 누르기 전에는 isHidden이 False로 설정
![image](https://github.com/user-attachments/assets/04e9a48d-ceb5-47ee-bafe-154c87a4a862)

[hidden-popup]
초기 비어 있는 notice-popup DB
![image](https://github.com/user-attachments/assets/b82cdbcf-9c95-40c3-8423-de67e30ded96)

프론트에서 학생 id랑 공지id 보내주면
![image](https://github.com/user-attachments/assets/b0ce588b-f47c-46eb-bab7-997dd41d818b)

notice-popup DB에 값 추가
![image](https://github.com/user-attachments/assets/af853873-d612-4e54-88cc-95ce7d2ea2a5)

이후 isHidden을 True로 바꾼 뒤 프론트에게 success 보내줌
따라서, 다시 show-notice-popup을 실행하면 아래처럼 True로 잘 적용된걸 볼 수 있음
![image](https://github.com/user-attachments/assets/f18a4719-32b2-43c8-8050-7b9435816aed)


