### PR TITLE
✨ Feat/#70 예약 관련 모든 마크업 및 api 연결

### DIFF
--- a/back/routes/showPopup
+++ b/back/routes/showPopup
@@ -15,21 +15,22 @@ router.post("/show-notice-popup", async (req, res) => {
 
     // 숨긴 공지 목록 조회
     const hiddenRecords = await NoticePopup.find({ studentId }).lean();
-    const hiddenIds = hiddenRecords.map(r => r.noticeId.toString());
+    const hiddenIds = hiddenRecords.map((r) => r.noticeId.toString());
 
-    const noticesWithHiddenFlag = popupNotices.map(n => {
-    const isHidden = hiddenIds.includes(n._id.toString());  // ✅ 문자열로 비교
-    return {
+    const noticesWithHiddenFlag = popupNotices.map((n) => {
+      const isHidden = hiddenIds.includes(n._id.toString()); // ✅ 문자열로 비교
+      return {
         id: n._id,
         start_date: n.start_date.toISOString().slice(0, 10),
         end_date: n.end_date.toISOString().slice(0, 10),
         title: n.title,
         contents: n.contents,
-        isHidden
-    };
+        isHidden,
+      };
     });
 
-    return res.status(200).json(noticesWithHiddenFlag);
+    const visibleNotices = noticesWithHiddenFlag.filter((n) => !n.isHidden);
+    return res.status(200).json(visibleNotices);
   } catch (err) {
     console.error("show-notice-popup 오류:", err);
     res.status(500).json({ message: "서버 오류" });

--- a/back/routes/showPopup
+++ b/back/routes/showPopup
@@ -21,15 +21,15 @@ router.post("/show-notice-popup", async (req, res) => {
       const isHidden = hiddenIds.includes(n._id.toString()); // ✅ 문자열로 비교
       return {
         id: n._id,
-        start_date: n.start_date.toISOString().slice(0, 10),
-        end_date: n.end_date.toISOString().slice(0, 10),
         title: n.title,
         contents: n.contents,
-        isHidden,
       };
     });
 
-    const visibleNotices = noticesWithHiddenFlag.filter((n) => !n.isHidden);
+    const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD 형식
+    const visibleNotices = noticesWithHiddenFlag.filter((n) => {
+      return !n.isHidden && n.start_date <= today && n.end_date >= today;
+    });
     return res.status(200).json(visibleNotices);
   } catch (err) {
     console.error("show-notice-popup 오류:", err);

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -68,6 +68,16 @@ const router = createBrowserRouter([
     ),
   },
   {
+    path: ROUTES.NOTICE_DETAIL.path,
+    element: (
+      <ProtectedRoute>
+        <Layout>
+          <ROUTES.NOTICE_DETAIL.element />
+        </Layout>
+      </ProtectedRoute>
+    ),
+  },
+  {
     path: ROUTES.MYPAGE.path,
     element: (
       <ProtectedRoute>

--- a/front/src/api/notice/dto/fetchNoticePopupDto.ts
+++ b/front/src/api/notice/dto/fetchNoticePopupDto.ts
@@ -1,8 +1,5 @@
 export interface fetchNoticePopupDto {
   id: string; // 공지 아이디
-  start_date: string; // 팝업 보여주기 시작할 시간
-  end_date: string; // 팝업 보여주기 끝낼 시간
   title: string; // 공지 제목
   contents: string; // 공지 내용
-  isHidden: boolean; // 공지 숨김 여부
 }

--- a/front/src/api/notice/dto/fetchNoticePopupDto.ts
+++ b/front/src/api/notice/dto/fetchNoticePopupDto.ts
@@ -1,0 +1,8 @@
+export interface fetchNoticePopupDto {
+  id: string; // 공지 아이디
+  start_date: string; // 팝업 보여주기 시작할 시간
+  end_date: string; // 팝업 보여주기 끝낼 시간
+  title: string; // 공지 제목
+  contents: string; // 공지 내용
+  isHidden: boolean; // 공지 숨김 여부
+}

--- a/front/src/api/notice/dto/fetchReservationNoticeDetailDto.ts
+++ b/front/src/api/notice/dto/fetchReservationNoticeDetailDto.ts
@@ -1,0 +1,7 @@
+export interface fetchReservationNoticeDetailDto {
+  id: string; // 공지 아이디
+  created_at: string; // 공지 작성 시간
+  type: boolean; // 공지 타입 (예: false: 고정, true: 팝업)
+  title: string; // 공지 제목
+  contents: string; // 공지 내용
+}

--- a/front/src/api/notice/dto/fetchReservationNoticesDto.ts
+++ b/front/src/api/notice/dto/fetchReservationNoticesDto.ts
@@ -1,6 +1,6 @@
 export interface fetchReservationNoticesDto {
   id: string; // 공지 아이디
-  created_at: Date; // 공지 작성 시간
+  created_at: string; // 공지 작성 시간
   type: boolean; // 공지 타입 (예: false: 고정, true: 팝업)
   title: string; // 공지 제목
 }

--- a/front/src/api/notice/dto/fetchReservationNoticesDto.ts
+++ b/front/src/api/notice/dto/fetchReservationNoticesDto.ts
@@ -1,6 +1,6 @@
 export interface fetchReservationNoticesDto {
   id: string; // 공지 아이디
   created_at: Date; // 공지 작성 시간
-  type: number; // 공지 타입 (예: 0: 고정, 1: 팝업 등)
+  type: boolean; // 공지 타입 (예: false: 고정, true: 팝업)
   title: string; // 공지 제목
 }

--- a/front/src/api/notice/dto/updateHiddenPopupDto.ts
+++ b/front/src/api/notice/dto/updateHiddenPopupDto.ts
@@ -1,0 +1,4 @@
+export interface updateHiddenPopupDto {
+  studentId: string; // 학생 아이디
+  noticeId: string; // 공지 아이디
+}

--- a/front/src/api/notice/fetchNoticePopup.ts
+++ b/front/src/api/notice/fetchNoticePopup.ts
@@ -4,7 +4,7 @@ export const fetchNoticePopup = async (studentId: string) => {
   try {
     const token = sessionStorage.getItem("accessToken"); // 세션스토리지에서 토큰을 가져옴
 
-    const response = await fetch("/api/reservation-detail", {
+    const response = await fetch("/api/show-notice-popup", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/front/src/api/notice/fetchNoticePopup.ts
+++ b/front/src/api/notice/fetchNoticePopup.ts
@@ -17,8 +17,7 @@ export const fetchNoticePopup = async (studentId: string) => {
       throw new Error("데이터를 가져오는 데 실패했습니다.");
     }
 
-    const rawData: fetchNoticePopupDto[] = await response.json();
-    const data = rawData.filter((item) => !item.isHidden);
+    const data: fetchNoticePopupDto[] = await response.json();
 
     return data;
   } catch (error) {

--- a/front/src/api/notice/fetchNoticePopup.ts
+++ b/front/src/api/notice/fetchNoticePopup.ts
@@ -17,7 +17,8 @@ export const fetchNoticePopup = async (studentId: string) => {
       throw new Error("데이터를 가져오는 데 실패했습니다.");
     }
 
-    const data: fetchNoticePopupDto = await response.json();
+    const rawData: fetchNoticePopupDto[] = await response.json();
+    const data = rawData.filter((item) => !item.isHidden);
 
     return data;
   } catch (error) {

--- a/front/src/api/notice/fetchNoticePopup.ts
+++ b/front/src/api/notice/fetchNoticePopup.ts
@@ -1,0 +1,27 @@
+import { fetchNoticePopupDto } from "./dto/fetchNoticePopupDto";
+
+export const fetchNoticePopup = async (studentId: string) => {
+  try {
+    const token = sessionStorage.getItem("accessToken"); // 세션스토리지에서 토큰을 가져옴
+
+    const response = await fetch("/api/reservation-detail", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ studentId }),
+    });
+
+    if (!response.ok) {
+      throw new Error("데이터를 가져오는 데 실패했습니다.");
+    }
+
+    const data: fetchNoticePopupDto = await response.json();
+
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch reservation notice detail", error);
+    throw error;
+  }
+};

--- a/front/src/api/notice/fetchReservationNoticeDetail.ts
+++ b/front/src/api/notice/fetchReservationNoticeDetail.ts
@@ -10,7 +10,7 @@ export const fetchReservationNoticeDetail = async (noticeId: string) => {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ noticeId }),
+      body: JSON.stringify({ id: noticeId }),
     });
 
     if (!response.ok) {

--- a/front/src/api/notice/fetchReservationNoticeDetail.ts
+++ b/front/src/api/notice/fetchReservationNoticeDetail.ts
@@ -4,7 +4,7 @@ export const fetchReservationNoticeDetail = async (noticeId: string) => {
   try {
     const token = sessionStorage.getItem("accessToken"); // 세션스토리지에서 토큰을 가져옴
 
-    const response = await fetch("/api/reservation-detail", {
+    const response = await fetch("/api/notice-detail", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/front/src/api/notice/fetchReservationNoticeDetail.ts
+++ b/front/src/api/notice/fetchReservationNoticeDetail.ts
@@ -1,0 +1,27 @@
+import { fetchReservationNoticeDetailDto } from "./dto/fetchReservationNoticeDetailDto";
+
+export const fetchReservationNoticeDetail = async (noticeId: string) => {
+  try {
+    const token = sessionStorage.getItem("accessToken"); // 세션스토리지에서 토큰을 가져옴
+
+    const response = await fetch("/api/reservation-detail", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ noticeId }),
+    });
+
+    if (!response.ok) {
+      throw new Error("데이터를 가져오는 데 실패했습니다.");
+    }
+
+    const data: fetchReservationNoticeDetailDto = await response.json();
+
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch reservation notice detail", error);
+    throw error;
+  }
+};

--- a/front/src/api/notice/fetchReservationNotices.ts
+++ b/front/src/api/notice/fetchReservationNotices.ts
@@ -1,3 +1,5 @@
+import { fetchReservationNoticesDto } from "./dto/fetchReservationNoticesDto";
+
 export const fetchReservationNotices = async () => {
   try {
     const response = await fetch("/api/notice-list");
@@ -6,7 +8,7 @@ export const fetchReservationNotices = async () => {
       throw new Error("데이터를 가져오는 데 실패했습니다.");
     }
 
-    const data = await response.json(); // JSON 형태로 응답 데이터 파싱
+    const data: fetchReservationNoticesDto[] = await response.json(); // JSON 형태로 응답 데이터 파싱
     return data;
   } catch (error) {
     console.error("Failed to fetch reservation notices:", error);

--- a/front/src/api/notice/updateHiddenPopup.ts
+++ b/front/src/api/notice/updateHiddenPopup.ts
@@ -1,0 +1,19 @@
+import { updateHiddenPopupDto } from "./dto/updateHiddenPopupDto";
+
+export const updateHiddenPopup = async (data: updateHiddenPopupDto) => {
+  const token = sessionStorage.getItem("accessToken");
+  const response = await fetch("/api/hidden-popup", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    throw new Error("회원 정보 수정에 실패했습니다.");
+  }
+
+  return response.json();
+};

--- a/front/src/components/Popup/NoticePopup.tsx
+++ b/front/src/components/Popup/NoticePopup.tsx
@@ -1,13 +1,33 @@
 import { createPortal } from "react-dom";
+import { useState, useEffect } from "react";
 import Button from "../Button";
 import { fetchNoticePopupDto } from "../../api/notice/dto/fetchNoticePopupDto";
+import { updateHiddenPopup } from "../../api/notice/updateHiddenPopup";
 
 interface NoticePopupProps {
+  studentId: string;
   notice: fetchNoticePopupDto;
   onClose: () => void;
 }
 
-const NoticePopup = ({ notice, onClose }: NoticePopupProps) => {
+const NoticePopup = ({ studentId, notice, onClose }: NoticePopupProps) => {
+  const [isHidden, setIsHidden] = useState(false);
+
+  useEffect(() => {
+    setIsHidden(false);
+  }, [notice.id]);
+
+  const handleConfirm = async () => {
+    if (isHidden) {
+      try {
+        await updateHiddenPopup({ studentId, noticeId: notice.id });
+      } catch (error) {
+        console.error("팝업 숨김 처리 실패:", error);
+      }
+    }
+    onClose();
+  };
+
   return createPortal(
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="flex flex-col bg-white w-full mx-4 max-w-md p-6 rounded-2xl relative shadow-xl border border-gray-200">
@@ -20,11 +40,13 @@ const NoticePopup = ({ notice, onClose }: NoticePopupProps) => {
             <input
               type="checkbox"
               className="form-checkbox h-4 w-4 text-purple-600 transition duration-150 ease-in-out"
+              checked={isHidden}
+              onChange={() => setIsHidden(!isHidden)}
             />
             <span>다시 보지 않기</span>
           </label>
           <div className="w-full">
-            <Button text={"확인"} onClick={onClose} isActive={true} />
+            <Button text={"닫기"} onClick={handleConfirm} isActive={true} />
           </div>
         </div>
       </div>

--- a/front/src/components/Popup/NoticePopup.tsx
+++ b/front/src/components/Popup/NoticePopup.tsx
@@ -1,0 +1,36 @@
+import { createPortal } from "react-dom";
+import Button from "../Button";
+import { fetchNoticePopupDto } from "../../api/notice/dto/fetchNoticePopupDto";
+
+interface NoticePopupProps {
+  notice: fetchNoticePopupDto;
+  onClose: () => void;
+}
+
+const NoticePopup = ({ notice, onClose }: NoticePopupProps) => {
+  return createPortal(
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="flex flex-col bg-white w-full mx-4 max-w-md p-6 rounded-2xl relative shadow-xl border border-gray-200">
+        <div className="flex flex-col items-center">
+          <h2 className="text-xl font-bold mb-3 text-center">{notice.title}</h2>
+          <p className="text-center whitespace-pre-wrap leading-relaxed mb-6">
+            {notice.contents}
+          </p>
+          <label className="flex items-center gap-2 mb-6 cursor-pointer">
+            <input
+              type="checkbox"
+              className="form-checkbox h-4 w-4 text-purple-600 transition duration-150 ease-in-out"
+            />
+            <span>다시 보지 않기</span>
+          </label>
+          <div className="w-full">
+            <Button text={"확인"} onClick={onClose} isActive={true} />
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default NoticePopup;

--- a/front/src/constants/routes.ts
+++ b/front/src/constants/routes.ts
@@ -7,7 +7,7 @@ import ReservationStatus from "../pages/ReservationStatus/ReservationStatus";
 import Notice from "../pages/Notice/Notice";
 import MyPage from "../pages/MyPage/MyPage";
 import ProfileDetail from "../pages/ProfileDetail/ProfileDetail";
-
+import NoticeDetail from "../pages/NoticeDetail/NoticeDetail";
 // 페이지 정보 상수
 export const ROUTES = {
   HOME: {
@@ -44,6 +44,11 @@ export const ROUTES = {
     path: "/notice",
     element: Notice,
     title: "예약 관련 공지",
+  },
+  NOTICE_DETAIL: {
+    path: "/notice/:noticeId",
+    element: NoticeDetail,
+    title: "공지사항 상세",
   },
   MYPAGE: {
     path: "/mypage",

--- a/front/src/pages/Home/Home.tsx
+++ b/front/src/pages/Home/Home.tsx
@@ -10,9 +10,9 @@ import { fetchNoticePopupDto } from "../../api/notice/dto/fetchNoticePopupDto";
 const Home = () => {
   const [popupList, setPopupList] = useState<fetchNoticePopupDto[]>([]);
   const [currentPopupIndex, setCurrentPopupIndex] = useState(0);
+  const studentId = sessionStorage.getItem("studentId");
 
   useEffect(() => {
-    const studentId = sessionStorage.getItem("studentId");
     if (studentId) {
       fetchNoticePopup(studentId).then((res) => {
         if (Array.isArray(res)) {
@@ -26,6 +26,7 @@ const Home = () => {
     <>
       {popupList.length > 0 && currentPopupIndex < popupList.length && (
         <NoticePopup
+          studentId={studentId || ""}
           notice={popupList[currentPopupIndex]}
           onClose={() => setCurrentPopupIndex(currentPopupIndex + 1)}
         />

--- a/front/src/pages/Home/Home.tsx
+++ b/front/src/pages/Home/Home.tsx
@@ -1,23 +1,48 @@
-"use client";
+import { useEffect, useState } from "react";
 import PageWrapper from "../../components/PageWrapper/PageWrapper";
 import NavigationButtons from "./components/NavigationButtons";
 import ReservationNotice from "./components/ReservationNotice";
 import UpcomingReservations from "./components/UpcomingReservations";
+import { fetchNoticePopup } from "../../api/notice/fetchNoticePopup";
+import NoticePopup from "../../components/Popup/NoticePopup";
+import { fetchNoticePopupDto } from "../../api/notice/dto/fetchNoticePopupDto";
 
 const Home = () => {
+  const [popupList, setPopupList] = useState<fetchNoticePopupDto[]>([]);
+  const [currentPopupIndex, setCurrentPopupIndex] = useState(0);
+
+  useEffect(() => {
+    const studentId = sessionStorage.getItem("studentId");
+    if (studentId) {
+      fetchNoticePopup(studentId).then((res) => {
+        if (Array.isArray(res)) {
+          setPopupList(res);
+        }
+      });
+    }
+  }, []);
+
   return (
-    <PageWrapper>
-      <div className="space-y-10 w-full max-w-lg mx-auto z-10">
-        {/* 상단 네비 버튼 */}
-        <NavigationButtons />
+    <>
+      {popupList.length > 0 && currentPopupIndex < popupList.length && (
+        <NoticePopup
+          notice={popupList[currentPopupIndex]}
+          onClose={() => setCurrentPopupIndex(currentPopupIndex + 1)}
+        />
+      )}
+      <PageWrapper>
+        <div className="space-y-10 w-full max-w-lg mx-auto z-10">
+          {/* 상단 네비 버튼 */}
+          <NavigationButtons />
 
-        {/* 다가오는 내 예약 목록 */}
-        <UpcomingReservations />
+          {/* 다가오는 내 예약 목록 */}
+          <UpcomingReservations />
 
-        {/* 강의실 이용 안내 게시글 미리보기 */}
-        <ReservationNotice />
-      </div>
-    </PageWrapper>
+          {/* 강의실 이용 안내 게시글 미리보기 */}
+          <ReservationNotice />
+        </div>
+      </PageWrapper>
+    </>
   );
 };
 

--- a/front/src/pages/Home/components/ReservationNotice.tsx
+++ b/front/src/pages/Home/components/ReservationNotice.tsx
@@ -3,6 +3,7 @@ import { fetchReservationNotices } from "../../../api/notice/fetchReservationNot
 import { fetchReservationNoticesDto } from "../../../api/notice/dto/fetchReservationNoticesDto.ts";
 import { Link } from "react-router-dom";
 import { Pin } from "lucide-react";
+import { ROUTES } from "../../../constants/routes.ts";
 
 const ReservationNotice = () => {
   const [notices, setNotices] = useState<fetchReservationNoticesDto[]>([]); // 공지 데이터를 저장할 상태
@@ -53,7 +54,12 @@ const ReservationNotice = () => {
 
   return (
     <section>
-      <h2 className="text-lg font-semibold mb-2">📢 예약 관련 공지</h2>
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-lg font-semibold">예약 관련 공지</h2>
+        <Link to={ROUTES.NOTICE.path} className="text-purple hover:underline">
+          + 더보기
+        </Link>
+      </div>
       <div className="bg-white rounded-xl p-4 shadow-sm space-y-2 border border-1 border-gray">
         {error ? (
           <p>

--- a/front/src/pages/Home/components/ReservationNotice.tsx
+++ b/front/src/pages/Home/components/ReservationNotice.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { fetchReservationNotices } from "../../../api/notice/fetchReservationNotices.ts"; // API 함수 임포트
 import { fetchReservationNoticesDto } from "../../../api/notice/dto/fetchReservationNoticesDto.ts";
 import { Link } from "react-router-dom";
-import { Pin } from "lucide-react";
 import { ROUTES } from "../../../constants/routes.ts";
 
 const ReservationNotice = () => {
@@ -74,7 +73,11 @@ const ReservationNotice = () => {
             >
               <div className="flex justify-between items-center gap-2">
                 <span className="flex items-center gap-x-1 truncate">
-                  {notice.type === false && <Pin strokeWidth={1.5} size={20} />}
+                  {notice.type === false ? (
+                    <span className="text-purple font-semibold">[중요]</span>
+                  ) : (
+                    <span>[일반]</span>
+                  )}
                   <span className="truncate">{notice.title}</span>
                 </span>
                 {notice.type === true && (

--- a/front/src/pages/Home/components/ReservationNotice.tsx
+++ b/front/src/pages/Home/components/ReservationNotice.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 import { fetchReservationNotices } from "../../../api/notice/fetchReservationNotices.ts"; // API 함수 임포트
 import { fetchReservationNoticesDto } from "../../../api/notice/dto/fetchReservationNoticesDto.ts";
 import { Link } from "react-router-dom";
+import { Pin } from "lucide-react";
+
 const ReservationNotice = () => {
   const [notices, setNotices] = useState<fetchReservationNoticesDto[]>([]); // 공지 데이터를 저장할 상태
   const [loading, setLoading] = useState<boolean>(true); // 데이터 로딩 상태
@@ -12,17 +14,17 @@ const ReservationNotice = () => {
         const data =
           (await fetchReservationNotices()) as fetchReservationNoticesDto[]; // 공지 데이터를 가져옴
 
-        // type이 0인 공지를 우선적으로 가져옴
-        const type0Notices = data.filter((notice) => notice.type === 0);
-        const type1Notices = data.filter((notice) => notice.type === 1);
+        // type이 false(기본 공지)를 우선적으로 가져옴
+        const defaultNotices = data.filter((notice) => notice.type === false);
+        const popupNotices = data.filter((notice) => notice.type === true);
 
-        // type이 0인 공지는 항상 가져오고, 최대 8개까지 가져와야 하므로
-        let combinedNotices = [...type0Notices];
+        // 기본 공지는 항상 가져오고, 최대 8개까지 가져와야 하므로
+        let combinedNotices = [...defaultNotices];
 
-        // type이 1인 공지 중에서 최신 순으로 최대 8개를 채움
+        // 팝업 공지 중에서 최신 순으로 최대 8개를 채움
         if (combinedNotices.length < 8) {
           const remainingCount = 8 - combinedNotices.length;
-          const latestType1Notices = type1Notices
+          const latestPopupNotices = popupNotices
             .sort(
               (a, b) =>
                 new Date(b.created_at).getTime() -
@@ -30,7 +32,7 @@ const ReservationNotice = () => {
             )
             .slice(0, remainingCount);
 
-          combinedNotices = [...combinedNotices, ...latestType1Notices];
+          combinedNotices = [...combinedNotices, ...latestPopupNotices];
         }
 
         setNotices(combinedNotices); // 데이터를 상태에 저장
@@ -62,13 +64,23 @@ const ReservationNotice = () => {
             <Link
               to={`/notice/${notice.id}`}
               key={notice.id}
-              className="block truncate border-b border-gray pb-2 pt-1 hover:text-purple transition-all duration-200"
+              className="block border-b border-gray pb-2 pt-1 hover:text-purple transition-all duration-200"
             >
-              {notice.type === 0 && "📌"} {notice.title}
+              <div className="flex justify-between items-center gap-2">
+                <span className="flex items-center gap-x-1 truncate">
+                  {notice.type === false && <Pin strokeWidth={1.5} size={20} />}
+                  <span className="truncate">{notice.title}</span>
+                </span>
+                {notice.type === true && (
+                  <span className="text-sm text-darkgray">
+                    {notice.created_at}
+                  </span>
+                )}
+              </div>
             </Link>
           ))
         ) : (
-          <p className="text-gray-500">공지사항이 없습니다.</p> // 공지가 없을 때 회색 텍스트
+          <p className="text-darkgray">공지사항이 없습니다.</p> // 공지가 없을 때 회색 텍스트
         )}
       </div>
     </section>

--- a/front/src/pages/Home/components/UpcomingReservations.tsx
+++ b/front/src/pages/Home/components/UpcomingReservations.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 import { fetchReservationList } from "../../../api/mypage/fetchReservationList.ts";
 import { fetchReservationListDto } from "../../../api/mypage/dto/fetchReservationListDto.ts";
 import ReservationDetailPopup from "../../../components/Popup/ReservationDetailPopup.tsx";
+import { ROUTES } from "../../../constants/routes.ts";
+import { Link } from "react-router-dom";
 
 const UpcomingReservations = () => {
   const [reservations, setReservations] = useState<fetchReservationListDto[]>(
@@ -54,7 +56,12 @@ const UpcomingReservations = () => {
 
   return (
     <section>
-      <h2 className="text-lg font-semibold mb-2">📅 다가오는 내 예약</h2>
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-lg font-semibold">다가오는 내 예약</h2>
+        <Link to={ROUTES.MYPAGE.path} className="text-purple hover:underline">
+          + 더보기
+        </Link>
+      </div>
       <div className="bg-white rounded-xl p-4 shadow-sm border border-gray">
         {error ? (
           <p className="text-red-500">{error}</p>

--- a/front/src/pages/Notice/Notice.tsx
+++ b/front/src/pages/Notice/Notice.tsx
@@ -51,9 +51,6 @@ const NoticePage = () => {
                     <span className="text-purple font-semibold">[중요]</span>{" "}
                     {notice.title}
                   </span>
-                  <span className="text-sm text-darkgray">
-                    {notice.created_at}
-                  </span>
                 </div>
               </Link>
             ))}

--- a/front/src/pages/Notice/Notice.tsx
+++ b/front/src/pages/Notice/Notice.tsx
@@ -1,7 +1,85 @@
+import { useEffect, useState } from "react";
 import PageWrapper from "../../components/PageWrapper/PageWrapper";
+import { fetchReservationNotices } from "../../api/notice/fetchReservationNotices";
+import { fetchReservationNoticesDto } from "../../api/notice/dto/fetchReservationNoticesDto";
+import { Link } from "react-router-dom";
 
 const NoticePage = () => {
-  return <PageWrapper>공지사항</PageWrapper>;
+  const [notices, setNotices] = useState<fetchReservationNoticesDto[]>([]); // 공지 데이터를 저장할 상태
+  const [loading, setLoading] = useState<boolean>(true); // 데이터 로딩 상태
+  const [error, setError] = useState<string | null>(null); // 에러 상태, 문자열 또는 null
+  useEffect(() => {
+    const getNotices = async () => {
+      try {
+        const data =
+          (await fetchReservationNotices()) as fetchReservationNoticesDto[]; // 공지 데이터를 가져옴
+
+        setNotices(data); // 데이터를 상태에 저장
+      } catch (err) {
+        console.error(err); // 오류 콘솔에 출력
+        setError("공지 정보를 불러오는 데 실패했습니다.");
+      } finally {
+        setLoading(false); // 로딩 종료
+      }
+    };
+
+    getNotices();
+  }, []); // 컴포넌트가 마운트될 때 한번만 실행
+
+  if (loading) {
+    return <div>Loading...</div>; // 로딩 중일 때
+  }
+
+  const importantNotices = notices.filter((n) => !n.type);
+  const generalNotices = notices.filter((n) => n.type);
+
+  return (
+    <PageWrapper>
+      <div className="space-y-2 w-full">
+        {error ? (
+          <p>{error}</p>
+        ) : notices.length > 0 ? (
+          <div className="shadow-sm border border-gray">
+            {importantNotices.map((notice) => (
+              <Link
+                to={`/notice/${notice.id}`}
+                key={notice.id}
+                className="p-4 block border-b border-gray hover:text-purple transition-all duration-200 bg-white"
+              >
+                <div className="flex justify-between items-center gap-2">
+                  <span className="flex items-center gap-x-1 truncate">
+                    <span className="text-purple font-semibold">[중요]</span>{" "}
+                    {notice.title}
+                  </span>
+                  <span className="text-sm text-darkgray">
+                    {notice.created_at}
+                  </span>
+                </div>
+              </Link>
+            ))}
+            {generalNotices.map((notice) => (
+              <Link
+                to={`/notice/${notice.id}`}
+                key={notice.id}
+                className="p-4  block border-b border-gray  hover:text-purple transition-all duration-200 bg-white bg-opacity-50"
+              >
+                <div className="flex justify-between items-center gap-2">
+                  <span className="flex items-center gap-x-1 truncate">
+                    [일반] {notice.title}
+                  </span>
+                  <span className="text-sm text-darkgray">
+                    {notice.created_at}
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <p className="text-darkgray">공지사항이 없습니다.</p>
+        )}
+      </div>
+    </PageWrapper>
+  );
 };
 
 export default NoticePage;

--- a/front/src/pages/NoticeDetail/NoticeDetail.tsx
+++ b/front/src/pages/NoticeDetail/NoticeDetail.tsx
@@ -1,0 +1,7 @@
+import PageWrapper from "../../components/PageWrapper/PageWrapper";
+
+const NoticeDetail = () => {
+  return <PageWrapper>공지사항 상세</PageWrapper>;
+};
+
+export default NoticeDetail;

--- a/front/src/pages/NoticeDetail/NoticeDetail.tsx
+++ b/front/src/pages/NoticeDetail/NoticeDetail.tsx
@@ -1,7 +1,45 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import PageWrapper from "../../components/PageWrapper/PageWrapper";
+import { fetchReservationNoticeDetail } from "../../api/notice/fetchReservationNoticeDetail";
+import { fetchReservationNoticeDetailDto } from "../../api/notice/dto/fetchReservationNoticeDetailDto";
 
 const NoticeDetail = () => {
-  return <PageWrapper>공지사항 상세</PageWrapper>;
+  const { noticeId } = useParams();
+  const [notice, setNotice] = useState<fetchReservationNoticeDetailDto | null>(
+    null
+  );
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    if (!noticeId) return;
+
+    fetchReservationNoticeDetail(noticeId)
+      .then(setNotice)
+      .catch(() => setError("공지사항을 불러오는 데 실패했습니다."));
+  }, [noticeId]);
+
+  return (
+    <PageWrapper>
+      {error ? (
+        <p className="text-red">{error}</p>
+      ) : notice ? (
+        <div className="bg-white bg-opacity-50 p-6 rounded-xl space-y-4 w-full">
+          <h1 className="text-xl font-bold text-purple">
+            {notice.type === false ? "[중요]" : "[일반]"} {notice.title}
+          </h1>
+          <p className="text-sm text-black">
+            {new Date(notice.created_at).toLocaleDateString()}
+          </p>
+          <hr className="border-t border-darkgray" />
+          <div className="text-black whitespace-pre-wrap leading-relaxed">
+            {notice.contents}
+          </div>
+        </div>
+      ) : (
+        <p className="text-center text-gray-500">로딩 중...</p>
+      )}
+    </PageWrapper>
+  );
 };
 
 export default NoticeDetail;

--- a/front/src/pages/NoticeDetail/NoticeDetail.tsx
+++ b/front/src/pages/NoticeDetail/NoticeDetail.tsx
@@ -24,7 +24,7 @@ const NoticeDetail = () => {
         <p className="text-red">{error}</p>
       ) : notice ? (
         <div className="bg-white bg-opacity-50 p-6 rounded-xl space-y-4 w-full">
-          <h1 className="text-xl font-bold text-purple">
+          <h1 className="text-xl font-bold ">
             {notice.type === false ? "[중요]" : "[일반]"} {notice.title}
           </h1>
           <p className="text-sm text-black">


### PR DESCRIPTION
### 👀 관련 이슈

#70

### ✨ 작업한 내용
- 홈페이지 공지 목록 보기 api 연결
- 공지 상세페이지 마크업, api 연결
- 예약 관련 공지페이지 마크업, api 연결
- 공지 팝업 컴포넌트 마크업, api 연결
- 다시 보지 않음 누르면 api요청

### 🍰 참고사항

백엔드의 /api/show-notice-popup에서 변경사항 있습니다.
- isHidden이 false인 데이터만 보내주도록 변경
- startDate~endDate 사이의 날짜일 때만 보내주도록 변경

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|   홈 페이지에서 공지 목록 보기, 공지 상세   |   ![홈에서 공지 목록](https://github.com/user-attachments/assets/6ddf34ed-2317-43cc-ab22-f08f1ce93c29)      |
|   `예약 관련 공지` 메뉴에서 공지 목록 보기, 공지 상세 <br> **중요 공지는 항상 상단에 고정되도록**   |      ![예약관련공지 페이지](https://github.com/user-attachments/assets/5cfaf901-da41-4c38-954d-5dd5cc2550e6)    |
|   팝업 공지, 다시보지않기 클릭시 재로딩될 때 안뜨도록   |     ![팝업공지, 다시보지않기](https://github.com/user-attachments/assets/e1cec3c6-876b-4d2e-8534-0acccd477d77)     |

