### PR TITLE
♻️ 몽고디비에 맞춰서 시간표 학기 적용 Refactor/#76

### DIFF
--- a/back/db/classBySemester.js
+++ b/back/db/classBySemester.js
@@ -1,0 +1,40 @@
+// db/classBySemester.js
+const mongoose = require('mongoose');
+const { classDB } = require('./mongodb');
+
+const classSchema = new mongoose.Schema({
+  class_idx: { type: String, required: true, unique: true },
+  classroom_idx: { type: String },
+  class_name: { type: String, required: true },
+  prof_name: { type: String, required: true },
+  class_credit: { type: Number, required: true },
+  class_daytime: { type: String, required: true },
+  department: { type: String },
+  building: { type: String },
+  room: { type: String },
+  week_mon: Boolean,
+  week_tue: Boolean,
+  week_wed: Boolean,
+  week_thu: Boolean,
+  week_fri: Boolean,
+  mon_start_time: String,
+  mon_end_time: String,
+  tue_start_time: String,
+  tue_end_time: String,
+  wed_start_time: String,
+  wed_end_time: String,
+  thu_start_time: String,
+  thu_end_time: String,
+  fri_start_time: String,
+  fri_end_time: String
+}, { versionKey: false });
+
+// 경우에 따라 다른 클렌션을 통해 수업을 찾아오기 위해 모델이 있으면 reuse 하는 기능
+const getClassModelBySemester = (collectionName) => {
+  if (mongoose.models[collectionName]) {
+    return mongoose.models[collectionName];
+  }
+  return classDB.model(collectionName, classSchema, collectionName);
+};
+
+module.exports = getClassModelBySemester;

--- a/back/routes/classroomReservation.js
+++ b/back/routes/classroomReservation.js
@@ -2,10 +2,11 @@ const express = require("express");
 const router = express.Router();
 const ClassroomInfo = require("../db/classroomInfo");
 const Reservation = require("../db/reservation");
-const Class = require("../db/class");
 const Student = require("../db/student");
 const { ObjectId } = require("mongodb");
 const auth = require("../middlewares/authMiddleware");
+const { classDB } = require("../db/mongodb");
+const Schedule = classDB.collection("schedule");
 
 const buildingMap = {
   복지관: "복", 비마관: "비", 새빛관: "새빛", 연구관: "연", 옥의관: "옥",
@@ -15,6 +16,16 @@ const buildingMap = {
 const getWeekdayKey = (dateStr) => {
   const days = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
   return days[new Date(dateStr).getDay()];
+};
+
+const getSemesterByDate = async (dateStr) => {
+  const targetDate = new Date(dateStr);
+  const semesterDoc = await Schedule.findOne({
+    start_time: { $lte: targetDate },
+    end_time: { $gte: targetDate },
+  });
+  if (!semesterDoc) return null;
+  return `${semesterDoc.year}-${semesterDoc.semester}`;
 };
 
 router.post("/classroom-reservation", auth, async (req, res) => {
@@ -30,7 +41,7 @@ router.post("/classroom-reservation", auth, async (req, res) => {
 
     const startOfDay = new Date(`${date}T00:00:00`);
     const endOfDay = new Date(`${date}T23:59:59`);
-    const weekday = getWeekdayKey(date); // mon, tue, ...
+    const weekday = getWeekdayKey(date);
 
     // ✅ 예약 정보 가져오기
     const reservations = await Reservation.find({
@@ -49,10 +60,14 @@ router.post("/classroom-reservation", auth, async (req, res) => {
       };
     }));
 
-    // ✅ 수업 정보 가져오기
+    // ✅ 수업 정보 가져오기 (동적 컬렉션)
+    const semesterKey = await getSemesterByDate(date);
+    if (!semesterKey) return res.status(200).json([...reservationResults]);
+
+    const Class = classDB.collection(semesterKey);
     const shortRoom = room.replace("호", "");
     const roomIdx = `${buildingMap[building] || ""}${shortRoom}`;
-    const classResults = await Class.find({ classroom_idx: roomIdx }).lean();
+    const classResults = await Class.find({ classroom_idx: roomIdx }).toArray();
 
     const lectureResults = classResults
       .filter(c => c[`week_${weekday}`])

--- a/back/routes/makereserve.js
+++ b/back/routes/makereserve.js
@@ -2,12 +2,25 @@ const express = require("express");
 const router = express.Router();
 const ClassroomInfo = require("../db/classroomInfo");
 const Reservation = require("../db/reservation");
+const Schedule = require("../db/mongodb").classDB.collection("schedule");
 const auth = require("../middlewares/authMiddleware");
+const { classDB } = require("../db/mongodb");
 
 // 시간 포맷 보정 함수 (선택사항)
 const formatTime = (timeStr) => {
   const [h, m] = timeStr.split(":");
   return `${h.padStart(2, "0")}:${m.padStart(2, "0")}`;
+};
+
+// 학기명 조회 함수
+const getSemesterByDate = async (dateStr) => {
+  const targetDate = new Date(dateStr);
+  const semesterDoc = await Schedule.findOne({
+    start_time: { $lte: targetDate },
+    end_time: { $gte: targetDate },
+  });
+  if (!semesterDoc) return null;
+  return `${semesterDoc.year}-${semesterDoc.semester}`;
 };
 
 // POST /api/make-reservation
@@ -34,11 +47,11 @@ router.post("/make-reservation", auth, async (req, res) => {
       return res.status(404).json({ message: "해당 강의실 정보 없음" });
     }
 
-    // 시간 포맷 보정 (예: "9:0" → "09:00")
+    // 시간 포맷 보정
     const formattedStartTime = formatTime(startTime);
     const formattedEndTime = formatTime(endTime);
 
-    // ✅ 중복 예약 확인
+    // ✅ 중복 예약 확인 (예약)
     const duplicate = await Reservation.findOne({
       classroom_info_id: classroom._id,
       reserve_date: new Date(date),
@@ -48,6 +61,35 @@ router.post("/make-reservation", auth, async (req, res) => {
 
     if (duplicate) {
       return res.status(409).json({ message: "해당 시간에 이미 예약이 존재합니다." });
+    }
+
+    // ✅ 중복 확인 (강의)
+    const semesterKey = await getSemesterByDate(date);
+    if (semesterKey) {
+      const classCollection = classDB.collection(semesterKey);
+
+      const buildingPrefix = {
+        복지관: "복", 비마관: "비", 새빛관: "새빛", 연구관: "연", 옥의관: "옥",
+        참빛관: "참", 한울관: "한울", 화도관: "화", 기념관: "기", 누리관: "누"
+      }[building];
+
+      const classroomIdx = buildingPrefix ? `${buildingPrefix}${room.replace("호", "")}` : null;
+
+      if (classroomIdx) {
+        const weekday = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"][new Date(date).getDay()];
+
+        const classResults = await classCollection.find({ classroom_idx: classroomIdx }).toArray();
+        const hasOverlap = classResults.some(cls => {
+          if (!cls[`week_${weekday}`]) return false;
+          const classStart = cls[`${weekday}_start_time`];
+          const classEnd = cls[`${weekday}_end_time`];
+          return classStart < formattedEndTime && classEnd > formattedStartTime;
+        });
+
+        if (hasOverlap) {
+          return res.status(409).json({ message: "해당 시간에 강의가 이미 배정되어 있습니다." });
+        }
+      }
     }
 
     // ✅ 새 예약 생성

--- a/back/routes/reservation.js
+++ b/back/routes/reservation.js
@@ -2,11 +2,11 @@ const express = require("express");
 const router = express.Router();
 const { classDB } = require("../db/mongodb");
 const { ObjectId } = require("mongodb");
-
-const Class = classDB.collection("class");
-const Reserve = classDB.collection("reserve");
-const ClassroomInfo = classDB.collection("classroom_info"); // ✅ 추가
 const auth = require("../middlewares/authMiddleware");
+
+const Reserve = classDB.collection("reserve");
+const ClassroomInfo = classDB.collection("classroom_info");
+const Schedule = classDB.collection("schedule");
 
 // 요일 매핑
 const getDayField = (dateStr) => {
@@ -20,6 +20,18 @@ const buildingMap = {
   미지정: null, "": null,
 };
 
+// 학기명 조회 함수
+const getSemesterByDate = async (dateStr) => {
+  const targetDate = new Date(dateStr);
+  const semesterDoc = await Schedule.findOne({
+    start_time: { $lte: targetDate },
+    end_time: { $gte: targetDate },
+  });
+
+  if (!semesterDoc) return null;
+  return `${semesterDoc.year}-${semesterDoc.semester}`;
+};
+
 // POST /api/reserve/check-time
 router.post("/reserve/check-time", auth, async (req, res) => {
   try {
@@ -28,7 +40,7 @@ router.post("/reserve/check-time", auth, async (req, res) => {
       return res.status(400).json({ message: "date, building, room 필수" });
     }
 
-    const weekday = getDayField(date); // 예: mon
+    const weekday = getDayField(date);
 
     // ✅ classroom_info_id 찾기
     const classroom = await ClassroomInfo.findOne({ building, room });
@@ -42,7 +54,7 @@ router.post("/reserve/check-time", auth, async (req, res) => {
         $gte: new Date(date + "T00:00:00.000Z"),
         $lt: new Date(date + "T23:59:59.999Z"),
       },
-      classroom_info_id: classroom._id // ✅ 필드 수정
+      classroom_info_id: classroom._id
     }).toArray();
 
     const reservationTimes = reservationResults.map((r) => ({
@@ -50,7 +62,14 @@ router.post("/reserve/check-time", auth, async (req, res) => {
       endTime: r.reserve_end_time,
     }));
 
-    // 2️⃣ 수업 정보 조회
+    // 2️⃣ 학기에 맞는 강의 정보 조회
+    const semesterKey = await getSemesterByDate(date);
+    if (!semesterKey) {
+      return res.status(200).json([...reservationTimes]); // 학기 없으면 예약만 반환
+    }
+
+    const Class = classDB.collection(semesterKey);
+
     const buildingPrefix = buildingMap[building];
     const computedClassroomIdx = buildingPrefix
       ? `${buildingPrefix}${room.replace("호", "")}`
@@ -70,7 +89,6 @@ router.post("/reserve/check-time", auth, async (req, res) => {
         endTime: cls[`${weekday}_end_time`],
       }));
 
-    // 3️⃣ 합쳐서 응답
     return res.status(200).json([...reservationTimes, ...classTimes]);
   } catch (err) {
     console.error("check-time 오류:", err);

--- a/back/routes/updatereserve.js
+++ b/back/routes/updatereserve.js
@@ -4,6 +4,23 @@ const ClassroomInfo = require("../db/classroomInfo");
 const Reservation = require("../db/reservation");
 const { ObjectId } = require("mongodb");
 const auth = require("../middlewares/authMiddleware");
+const { classDB } = require("../db/mongodb");
+const Schedule = classDB.collection("schedule");
+
+const formatTime = (timeStr) => {
+  const [h, m] = timeStr.split(":");
+  return `${h.padStart(2, "0")}:${m.padStart(2, "0")}`;
+};
+
+const getSemesterByDate = async (dateStr) => {
+  const targetDate = new Date(dateStr);
+  const semesterDoc = await Schedule.findOne({
+    start_time: { $lte: targetDate },
+    end_time: { $gte: targetDate },
+  });
+  if (!semesterDoc) return null;
+  return `${semesterDoc.year}-${semesterDoc.semester}`;
+};
 
 router.put("/update-reservation", auth, async (req, res) => {
   try {
@@ -20,36 +37,75 @@ router.put("/update-reservation", auth, async (req, res) => {
       participantCount,
     } = req.body;
 
-    // 필수값 확인
     if (!reservationId || !studentId || !date || !building || !room || !startTime || !endTime || !purpose || !professor || !participantCount) {
       return res.status(400).json({ message: "필수 입력값 누락" });
     }
 
-    // 기존 예약 조회
     const existing = await Reservation.findOne({ _id: new ObjectId(reservationId) });
     if (!existing) {
       return res.status(404).json({ message: "해당 예약을 찾을 수 없습니다." });
     }
 
-    // 본인 예약인지 확인
     if (existing.student_id !== studentId) {
       return res.status(403).json({ message: "본인의 예약만 수정할 수 있습니다." });
     }
 
-    // 강의실 정보 다시 확인
     const classroom = await ClassroomInfo.findOne({ building, room });
     if (!classroom) {
       return res.status(404).json({ message: "해당 강의실 정보 없음" });
     }
 
-    // 예약 정보 업데이트
+    const formattedStartTime = formatTime(startTime);
+    const formattedEndTime = formatTime(endTime);
+
+    const conflict = await Reservation.findOne({
+      _id: { $ne: new ObjectId(reservationId) },
+      classroom_info_id: classroom._id,
+      reserve_date: new Date(date),
+      reserve_start_time: { $lt: formattedEndTime },
+      reserve_end_time: { $gt: formattedStartTime },
+    });
+
+    if (conflict) {
+      return res.status(409).json({ message: "해당 시간에 다른 예약이 존재합니다." });
+    }
+
+    // ✅ 수업 중복 체크
+    const semesterKey = await getSemesterByDate(date);
+    if (semesterKey) {
+      const classCollection = classDB.collection(semesterKey);
+
+      const buildingPrefix = {
+        복지관: "복", 비마관: "비", 새빛관: "새빛", 연구관: "연", 옥의관: "옥",
+        참빛관: "참", 한울관: "한울", 화도관: "화", 기념관: "기", 누리관: "누"
+      }[building];
+
+      const classroomIdx = buildingPrefix ? `${buildingPrefix}${room.replace("호", "")}` : null;
+
+      if (classroomIdx) {
+        const weekday = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"][new Date(date).getDay()];
+
+        const classResults = await classCollection.find({ classroom_idx: classroomIdx }).toArray();
+        const hasOverlap = classResults.some(cls => {
+          if (!cls[`week_${weekday}`]) return false;
+          const classStart = cls[`${weekday}_start_time`];
+          const classEnd = cls[`${weekday}_end_time`];
+          return classStart < formattedEndTime && classEnd > formattedStartTime;
+        });
+
+        if (hasOverlap) {
+          return res.status(409).json({ message: "해당 시간에 강의가 이미 배정되어 있습니다." });
+        }
+      }
+    }
+
     await Reservation.updateOne(
       { _id: new ObjectId(reservationId) },
       {
         $set: {
           reserve_date: new Date(date),
-          reserve_start_time: startTime,
-          reserve_end_time: endTime,
+          reserve_start_time: formattedStartTime,
+          reserve_end_time: formattedEndTime,
           classroom_info_id: classroom._id,
           professor,
           participant_count: participantCount,


### PR DESCRIPTION
### 👀 관련 이슈

#76 

### ✨ 작업한 내용

강의 정보는 class DB 안의 여러 컬렉션(예: 2025-1, 2024-겨울)에 연도/학기별로 나눠서 저장됨
- schedule 컬렉션을 활용해서 날짜(date)에 따라 해당 학기/컬렉션을 판별해야 함

/api/reserve/check-time
1) schedule 컬렉션에서 date가 포함된 학기 추출 → 2) 해당 학기 컬렉션 접근 후 강의 시간 조회
/api/make-reservation
1) 중복 예약 여부 확인 시 classroom_idx 기반 강의 시간 확인 → 위와 동일하게 해당 학기에서 검사
/api/update-reservation
1) 예약 정보 수정 시 시간 중복 체크 → 위와 동일
/api/classroom-reservation
1) 특정 날짜, 건물, 강의실에 해당하는 예약/강의 정보 모두 조회 → 강의는 해당 학기에서 가져오기

### 🌀 PR Point

포스트맨, 프론트 테스트 완료

### 🍰 참고사항

몽고 디비 중에서 [24-2]에 classroom_idx가 없어요 -> 24-2는 삭제
<img width="449" alt="image" src="https://github.com/user-attachments/assets/1ae99d15-a86d-4dfd-9c2d-c6352e032360" />

schedule에 [24-2]랑 [25-1]밖에 없어서 [24-겨울] 확인 불가 
<img width="781" alt="image" src="https://github.com/user-attachments/assets/458ee6e6-ddc1-4500-9cd1-c2f06ab528d7" />
-> "24-2" 삭제 후 "24-겨울" 추가 완료
<img width="443" alt="image" src="https://github.com/user-attachments/assets/94380682-4832-483b-80d6-b79a4add670c" />


### 📷 스크린샷 또는 GIF
"25-1"에 잘 적용돼서 나옴
<img width="588" alt="image" src="https://github.com/user-attachments/assets/5c08c72e-0df5-4b1c-b1ad-57c531263845" />

"24-겨울" 확인 완료
![image](https://github.com/user-attachments/assets/84dcf256-b419-4ef1-a578-ec40fed839ab)
![image](https://github.com/user-attachments/assets/f3366d96-5b9d-4630-8a25-d87aaaa3b924)
![image](https://github.com/user-attachments/assets/03fd69ee-5b89-4d9a-98dd-e884db35ae44)
